### PR TITLE
Fix bcal cmac free memleak

### DIFF
--- a/AESLib.c
+++ b/AESLib.c
@@ -34,6 +34,7 @@ void aes128_cbc_enc(const uint8_t* key, const uint8_t* iv, void* data, const uin
 	uint8_t r;
 	r = bcal_cbc_init(&aes128_desc, key, 128, &ctx);
 	if (r) {
+		bcal_cbc_free(&ctx);
 		return;
 	}
 	bcal_cbc_encMsg(iv, data, data_len / 16, &ctx);
@@ -50,6 +51,7 @@ void aes192_cbc_enc(const uint8_t* key, const uint8_t* iv, void* data, const uin
 	uint8_t r;
 	r = bcal_cbc_init(&aes192_desc, key, 192, &ctx);
 	if (r) {
+		bcal_cbc_free(&ctx);
 		return;
 	}
 	bcal_cbc_encMsg(iv, data, data_len / 16, &ctx);

--- a/bcal-basic.c
+++ b/bcal-basic.c
@@ -57,9 +57,11 @@ void bcal_cipher_free(bcgen_ctx_t* ctx){
 		return;
 	bc_free_fpt free_fpt;
 	free_fpt = (bc_free_fpt)(pgm_read_word(&(ctx->desc_ptr->free)));
-	if(free_fpt)
+	if(free_fpt) {
 		free_fpt((ctx->ctx));
-	free(ctx->ctx);
+	} else {
+		free(ctx->ctx);
+	}
 }
 
 void bcal_cipher_enc(void* block, const bcgen_ctx_t* ctx){

--- a/bcal-cmac.c
+++ b/bcal-cmac.c
@@ -91,6 +91,7 @@ void bcal_cmac_free(bcal_cmac_ctx_t* ctx){
 	free(ctx->accu);
 	free(ctx->k1);
 	free(ctx->k2);
+	free(ctx->lastblock);
 	bcal_cipher_free(&(ctx->cctx));
 }
 


### PR DESCRIPTION
Fixed missing free on 'ctx->lastblock'.
This caused a memleak when using 'bcal_cmac_init'.